### PR TITLE
setup_timer_0

### DIFF
--- a/Practica 3 prueba 2.c
+++ b/Practica 3 prueba 2.c
@@ -25,7 +25,7 @@ void timer_0()
 
 void main()
 {
-   setup_timer_0(rtcc_internal|rtcc_div_1);   
+   setup_timer_0(rtcc_internal|rtcc_div_256|rtcc_8_bit);   
    enable_interrupts(int_timer0);
    enable_interrupts(global);
    set_tris_A(0x00);


### PR DESCRIPTION
se ha puesto a timer 0 con preescalador de 256 y además, se le asignó que fuera en modo de 8 bits,
antes:
setup_timer_0(rtcc_internal|rtcc_div_1); 

despues:
setup_timer_0(rtcc_internal|rtcc_div_256|rtcc_8_bit); 

con estos cambios ya funciona el contador como debería y con el preescalador que debe, no lo hacía con el valor adecuado porque tomaba a timer 0 por defecto en 16 bit